### PR TITLE
Bump skypilot to 0.8.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dependencies = [
     "Click",
     "ray[default]",
-    "skypilot==0.7.0",
+    "skypilot==0.8.0",
     "hiyapyco'"
 ]
 [dependencies]


### PR DESCRIPTION
This is untested, but I only built skypilot 0.8.0 on conda-forge. Is there a particular incompatibility this prevents?

Ping @Stephan-Mai-pymc 